### PR TITLE
Update sat-hunting.md with how to transfer specific sats

### DIFF
--- a/docs/src/guides/sat-hunting.md
+++ b/docs/src/guides/sat-hunting.md
@@ -243,7 +243,8 @@ button to display the descriptor.
 
 ### Transferring Ordinals
 
-The `ord` wallet supports transferring specific satoshis. You can also use
-`bitcoin-cli` commands `createrawtransaction`, `signrawtransactionwithwallet`,
-and `sendrawtransaction`, how to do so is complex and outside the scope of this
-guide.
+The `ord` wallet supports transferring specific satoshis by using the 
+name of the sastoshi with the `ord wallet send` command. You can also use the
+`bitcoin-cli` commands `createrawtransaction`, `signrawtransactionwithwallet`, 
+and `sendrawtransaction`, but this method can be complex and is outside the 
+scope of this guide.


### PR DESCRIPTION
Added the key information about needing to use the sat name in order to transfer a specific uninscribed sat using ord wallet send.